### PR TITLE
update README.md to add upgrade instructions per CLI's nag

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ sam --version
 
 If you get a permission error when using npm (such as `EACCES: permission denied`), please see the instructions on this page of the NPM documentation: [https://docs.npmjs.com/getting-started/fixing-npm-permissions](https://docs.npmjs.com/getting-started/fixing-npm-permissions).
 
+#### Upgrading via npm
+
+To update **`sam`** once installed via npm:
+
+```bash
+npm update -g aws-sam-local
+```
+
 ### Binary release
 
 We also release the CLI as binaries that you can download and instantly use. You can find them under [Releases] in this repo. In case you cannot find the version or architecture you're looking for you can refer to [Build From Source](#build-from-source) section for build details.
@@ -96,6 +104,7 @@ This will install **`sam`** to your `$GOPATH/bin` folder. Make sure this directo
 ```bash
 aws-sam-local --help
 ```
+
 
 ## Usage
 


### PR DESCRIPTION
The CLI from time to time will provide a nag statement about a new version upgrading and sends you to the README to find out more information. That information doesn't exist today. This PR adds a simple section about upgrading with npm